### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/common/file_utils.py
+++ b/common/file_utils.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
+from urllib.parse import urlparse
 
 import tarfile
 import os
@@ -112,7 +113,8 @@ def get_file(fname, origin, untar=False,
     '''
 
     if download:
-        if 'modac.cancer.gov' in origin:
+        from urllib.parse import urlparse
+        if urlparse(origin).hostname and urlparse(origin).hostname.endswith(".modac.cancer.gov"):
             get_file_from_modac(fpath, origin)
         else:
             print('Downloading data from', origin)


### PR DESCRIPTION
Potential fix for [https://github.com/CBIIT/NCI-DOE-Collab-Pilot1-Cancer-Type-Classifier-Based-on-Somatic-Mutations/security/code-scanning/1](https://github.com/CBIIT/NCI-DOE-Collab-Pilot1-Cancer-Type-Classifier-Based-on-Somatic-Mutations/security/code-scanning/1)

To fix the issue, the code should parse the `origin` URL using `urllib.parse.urlparse` and validate its hostname instead of performing a substring check. This ensures that the URL belongs to the intended domain (`modac.cancer.gov`) and prevents malicious URLs from bypassing the check.

**Steps to implement the fix:**
1. Import `urlparse` from `urllib.parse` if not already imported.
2. Replace the substring check `'modac.cancer.gov' in origin` with a hostname validation using `urlparse(origin).hostname`.
3. Ensure the hostname ends with `.modac.cancer.gov` to allow subdomains if necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
